### PR TITLE
Automate Validation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,14 +19,12 @@ script:
 - stat ./environment/aws_config
 - docker build --pull --cache-from "$IMAGE_NAME" --tag "$IMAGE_NAME" --file environment/Dockerfile
   .
+- docker build -f experiments/ASO_Tuolumne/Dockerfile
 after_script:
 - docker images
-after_success:
-- docker --version
-- pip install --user awscli
-- aws configure set aws_access_key_id $AWS_ACCESS_KEY_ID
-- aws configure set aws_secret_access_key $AWS_SECRET_ACCESS_KEY
-- aws configure set default.region us-west-2
-- export PATH=$PATH:$HOME/.local/bin
-- eval $(aws ecr get-login --no-include-email --region us-west-2)
-- docker push "$IMAGE_NAME"
+
+deploy:
+  provider: script
+  script: bash scripts/deploy.sh
+  on:
+    branch: master

--- a/experiments/ASO_Tuolumne/Dockerfile
+++ b/experiments/ASO_Tuolumne/Dockerfile
@@ -1,0 +1,27 @@
+FROM ubuntu:16.04
+
+MAINTAINER Tony Cannistra <tony.cannistra@gmail.com>
+
+RUN apt-get update \
+    && apt-get install -y software-properties-common curl \
+    && apt autoremove -y \
+    && apt-get update \
+    && apt-get install -y build-essential
+
+RUN apt-get -y update && apt-get install -y --no-install-recommends \
+         wget \
+         nginx \
+         bzip2 \
+		     libgcc-5-dev \
+         ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+# Anaconda
+RUN wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh
+RUN bash Miniconda3-latest-Linux-x86_64.sh -b
+ENV PATH /root/miniconda3/bin:$PATH
+
+
+# Install dependancies
+COPY process_results.yml /opt/program/
+RUN conda env update --file /opt/program/process_results.yml

--- a/experiments/ASO_Tuolumne/Dockerfile
+++ b/experiments/ASO_Tuolumne/Dockerfile
@@ -26,3 +26,5 @@ ENV PATH /root/miniconda3/bin:$PATH
 # Install dependancies
 COPY process_results.yml /opt/program/
 RUN conda env update --file /opt/program/process_results.yml
+
+RUN pip install --upgrade awscli

--- a/experiments/ASO_Tuolumne/Dockerfile
+++ b/experiments/ASO_Tuolumne/Dockerfile
@@ -14,6 +14,7 @@ RUN apt-get -y update && apt-get install -y --no-install-recommends \
          bzip2 \
 		     libgcc-5-dev \
          ca-certificates libspatialindex-dev \
+         libsm6 libxext6 libxrender-dev cmake \
     && rm -rf /var/lib/apt/lists/*
 
 # Anaconda

--- a/experiments/ASO_Tuolumne/Dockerfile
+++ b/experiments/ASO_Tuolumne/Dockerfile
@@ -14,23 +14,13 @@ RUN apt-get -y update && apt-get install -y --no-install-recommends \
          bzip2 \
 		     libgcc-5-dev \
          ca-certificates libspatialindex-dev \
+         libsm6 libxext6 libxrender-dev cmake \
     && rm -rf /var/lib/apt/lists/*
 
 # Anaconda
 RUN wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh
 RUN bash Miniconda3-latest-Linux-x86_64.sh -b
 ENV PATH /root/miniconda3/bin:$PATH
-
-#needs:
-# albumentations
-# opencv libraries
-# apt-get install -y libsm6 libxext6 libxrender-dev
-# pip install opencv-python
-# conda install -c conda-forge imgaug
-#conda install albumentations -c conda-forgea
-# aws cli
-# credentials :(
-
 
 
 # Install dependancies

--- a/experiments/ASO_Tuolumne/Dockerfile
+++ b/experiments/ASO_Tuolumne/Dockerfile
@@ -13,13 +13,24 @@ RUN apt-get -y update && apt-get install -y --no-install-recommends \
          nginx \
          bzip2 \
 		     libgcc-5-dev \
-         ca-certificates \
+         ca-certificates libspatialindex-dev \
     && rm -rf /var/lib/apt/lists/*
 
 # Anaconda
 RUN wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh
 RUN bash Miniconda3-latest-Linux-x86_64.sh -b
 ENV PATH /root/miniconda3/bin:$PATH
+
+#needs:
+# albumentations
+# opencv libraries
+# apt-get install -y libsm6 libxext6 libxrender-dev
+# pip install opencv-python
+# conda install -c conda-forge imgaug
+#conda install albumentations -c conda-forgea
+# aws cli
+# credentials :(
+
 
 
 # Install dependancies

--- a/experiments/ASO_Tuolumne/Dockerfile
+++ b/experiments/ASO_Tuolumne/Dockerfile
@@ -14,7 +14,6 @@ RUN apt-get -y update && apt-get install -y --no-install-recommends \
          bzip2 \
 		     libgcc-5-dev \
          ca-certificates libspatialindex-dev \
-         libsm6 libxext6 libxrender-dev cmake \
     && rm -rf /var/lib/apt/lists/*
 
 # Anaconda

--- a/experiments/ASO_Tuolumne/Makefile
+++ b/experiments/ASO_Tuolumne/Makefile
@@ -1,0 +1,63 @@
+SHELL=/bin/bash
+
+VALIDATION_BUCKET ?= s3://planet-snowcover-validation/
+VALIDATION_MASKDIR ?= mask_tiles
+VALIDATION_IMAGEDIR ?= image_tiles
+
+MODEL_TRAIN_CONFIG ?= s3://planet-snowcover-experiments-2/co-train.toml
+MODEL_LOCATION ?= s3://planet-snowcover-experiments-2/planet-snowcover-2020-03-12-02-43-15-610
+MODEL_NAME ?= checkpoint-00050-of-00050.pth
+
+RSP ?= ../../model/robosat_pink
+
+RUN_WORKDIR = $(shell date +"%m-%d-%Y-%T")
+
+.PHONY: verify_token
+verify_token:
+ifeq ($(AWS_SECRET_ACCESS_KEY) && $(AWS_ACCESS_KEY_ID), )
+	$(error "AWS Token unavailable. Check credentials.")
+endif
+
+all: setup_aws config cleanup_aws
+
+setup_aws: verify_token
+ifeq ( $(wildcard ~/.aws/credentials) , )
+	mkdir -p ~/.aws/
+  echo "[default]" >> ~/.aws/credentials
+	echo "aws_access_key_id="$(AWS_ACCESS_KEY_ID) >> ~/.aws/credentials
+	echo "aws_secret_access_key="$(AWS_SECRET_ACCESS_KEY) >> ~/.aws/credentials
+else
+	mv ~/.aws/credentials ~/.aws/credentials.bak
+	echo "[default]" >> ~/.aws/credentials
+	echo "aws_access_key_id="$(AWS_ACCESS_KEY_ID) >> ~/.aws/credentials
+	echo "aws_secret_access_key="$(AWS_SECRET_ACCESS_KEY) >> ~/.aws/credentials
+endif
+
+cleanup_aws:
+ifeq ( $(wildcard ~/.aws/credentials.bak), )
+	rm ~/.aws/credentials
+else
+	mv ~/.aws/credentials.bak ~/.aws/credentials
+endif
+
+setup_dir:
+	mkdir -p "$(RUN_WORKDIR)/prediction"
+
+config: setup_dir
+ifeq ( $(findstring $(MODEL_TRAIN_CONFIG), s3), )
+		cp "$(MODEL_TRAIN_CONFIG)" "$(RUN_WORKDIR)/config.toml"
+else
+		aws --profile default s3 cp "$(MODEL_TRAIN_CONFIG)" "$(RUN_WORKDIR)/config.toml"
+endif
+
+
+run_prediction: config
+	cd $(RSP) && \
+		./rsp predict --create_tif \
+		--checkpoint $(MODEL_LOCATION)/$(MODEL_NAME)
+		--aws_profile default
+		--buffer --config "$(abspath $(RUN_WORKDIR))" \
+		"$(abspath $(RUN_WORKDIR))/prediction"
+
+# .PHONY cleanup
+# cleanup:

--- a/experiments/ASO_Tuolumne/Makefile
+++ b/experiments/ASO_Tuolumne/Makefile
@@ -1,6 +1,6 @@
 SHELL=/bin/bash
 
-VALIDATION_BUCKET ?= s3://planet-snowcover-validation/
+VALIDATION_BUCKET ?= s3://planet-snowcover-validation
 VALIDATION_MASKDIR ?= mask_tiles
 VALIDATION_IMAGEDIR ?= image_tiles
 
@@ -8,25 +8,27 @@ MODEL_TRAIN_CONFIG ?= s3://planet-snowcover-experiments-2/co-train.toml
 MODEL_LOCATION ?= s3://planet-snowcover-experiments-2/planet-snowcover-2020-03-12-02-43-15-610
 MODEL_NAME ?= checkpoint-00050-of-00050.pth
 
-RSP ?= ../../model/robosat_pink
+RSP ?= model/robosat_pink
 
 RUN_WORKDIR = $(shell date +"%m-%d-%Y-%T")
 
-.PHONY: verify_token
-verify_token:
-ifeq ($(AWS_SECRET_ACCESS_KEY) && $(AWS_ACCESS_KEY_ID), )
-	$(error "AWS Token unavailable. Check credentials.")
+.PHONY: verify_creds
+verify_creds:
+ifeq ($(and $(AWS_SECRET_ACCESS_KEY), $(AWS_ACCESS_KEY_ID)), )
+	$(error "AWS Credentials unavailable. Check credentials.")
 endif
 
-all: setup_aws config cleanup_aws
+all: setup_aws config run_prediction cleanup_aws
 
-setup_aws: verify_token
-ifeq ( $(wildcard ~/.aws/credentials) , )
+setup_aws: verify_creds
+ifeq (,$(wildcard ~/.aws/credentials/))
+	echo "Creating new AWS Credentials file."
 	mkdir -p ~/.aws/
-  echo "[default]" >> ~/.aws/credentials
+	echo "[default]" >> ~/.aws/credentials
 	echo "aws_access_key_id="$(AWS_ACCESS_KEY_ID) >> ~/.aws/credentials
 	echo "aws_secret_access_key="$(AWS_SECRET_ACCESS_KEY) >> ~/.aws/credentials
 else
+	echo "Backing up AWS Credentials File"
 	mv ~/.aws/credentials ~/.aws/credentials.bak
 	echo "[default]" >> ~/.aws/credentials
 	echo "aws_access_key_id="$(AWS_ACCESS_KEY_ID) >> ~/.aws/credentials
@@ -34,7 +36,7 @@ else
 endif
 
 cleanup_aws:
-ifeq ( $(wildcard ~/.aws/credentials.bak), )
+ifeq (,$(wildcard ~/.aws/credentials.bak))
 	rm ~/.aws/credentials
 else
 	mv ~/.aws/credentials.bak ~/.aws/credentials
@@ -53,11 +55,12 @@ endif
 
 run_prediction: config
 	cd $(RSP) && \
-		./rsp predict --create_tif \
-		--checkpoint $(MODEL_LOCATION)/$(MODEL_NAME)
-		--aws_profile default
-		--buffer --config "$(abspath $(RUN_WORKDIR))" \
-		"$(abspath $(RUN_WORKDIR))/prediction"
+		echo "./rsp predict --create_tif \
+		--checkpoint $(MODEL_LOCATION)/$(MODEL_NAME) \
+		--aws_profile default \
+		--tiles $(VALIDATION_BUCKET)/$(VALIDATION_IMAGEDIR) \
+		--buffer --config \"$(abspath $(RUN_WORKDIR))/config.toml\" \
+		\"$(abspath $(RUN_WORKDIR))/prediction\""
 
 # .PHONY cleanup
 # cleanup:

--- a/experiments/ASO_Tuolumne/process_results.yml
+++ b/experiments/ASO_Tuolumne/process_results.yml
@@ -1,4 +1,4 @@
-name: process_results
+name: base
 channels:
   - pytorch
   - conda-forge
@@ -25,6 +25,7 @@ dependencies:
   - python=3.6.8
   - pytorch=1.0.1
   - pytz=2018.3
+  - gdal=2.3.3
   - pyyaml=3.12
   - readline=7.0
   - requests=2.18.4
@@ -37,6 +38,7 @@ dependencies:
   - yaml=0.1.7
   - zlib=1.2.11
   - torchvision=0.2.0
+  - scikit-build
   - pip:
     - affine==2.2.2
     - boto3==1.7.2
@@ -70,3 +72,5 @@ dependencies:
     - webcolors==1.8.1
     - yaspin==0.14.1
     - geopandas
+    - rio-tiler
+    - albumentations


### PR DESCRIPTION
TODO:

- [x] Create a Docker image with `process_results.yml` conda environment as base that will allow for the production of validation statistics
  - [x] Modify Travis to test-build this new image also
- [x] Produce a Makefile which automates the following workflow: 
  - [x] Reversibly set AWS credentials provided to `make` as the `default` profile to allow for parameterization of credentials
  - [x] Parameterize local or S3-based configuration file locations + download remote (s3) config files + store locally
  - [ ]  Run prediction on selected validation image bucket (parameterized via `env` variable) given model output checkpoint (again via `env` or `make` variable) 
  - [ ] Gather prediction/mask/image tiles into central location
  - [ ] Produce mean/std validation metrics (precision/recall/f1) for the mask/pred pairs 

cc: @ajijohn 
